### PR TITLE
Fix the tests and relative imports for Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .idea
+.vscode
 .noseids
 .ropeproject
 .DS_Store

--- a/base/__init__.py
+++ b/base/__init__.py
@@ -9,4 +9,4 @@ base = Blueprint(
 )
 
 
-from views import *
+from .views import *

--- a/info/__init__.py
+++ b/info/__init__.py
@@ -9,4 +9,4 @@ info = Blueprint(
 )
 
 
-from views import *
+from .views import *

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -11,7 +11,7 @@
 """
 
 from flask import url_for
-from test_case import KitTestCase
+from .test_case import KitTestCase
 
 
 class TestFrontBlueprint(KitTestCase):

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -48,7 +48,7 @@ class KitTestCase(TestCase):
             msg_prefix + "Couldn't retrieve content: Response code was %d"
                          " (expected %d)" % (response.status_code, status_code))
 
-        real_count = response.data.count(text)
+        real_count = response.data.count(text.encode())
         if count is not None:
             self.assertEqual(real_count, count,
                 msg_prefix + "Found %d instances of '%s' in response"


### PR DESCRIPTION
Use explicit relative imports instead of implicit, which are not supported in Python 3; fix the failing test by encoding the string to bytes.